### PR TITLE
better handling of unknown escape sequences

### DIFF
--- a/vt102/__init__.py
+++ b/vt102/__init__.py
@@ -160,9 +160,9 @@ class stream:
 
         if self.sequence.has_key(ord(char)):
             self.dispatch(self.sequence[ord(char)], *self.params)
-            self.state = "stream"
-            self.current_param = ""
-            self.params = []
+        self.state = "stream"
+        self.current_param = ""
+        self.params = []
 
     def _escape_parameters(self, char):
         """


### PR DESCRIPTION
When there are escape sequences vt102 does not handle with parameters they end up being mixed in with the next one that it does know about. 

This fix allows the use of vt_tiledata[1]. 

Make sure you do not have a save you care about when trying this as it if breaks it will crash on restore and you will lose your save.

[1] http://alt.org/nethack/forum/read.php?6,334,338
