### PR TITLE
Update code to be py3k compatible.

### DIFF
--- a/test/test_vt102.py
+++ b/test/test_vt102.py
@@ -56,7 +56,7 @@ class TestStream(unittest.TestCase):
     def test_basic_escapes(self):
         s = stream()
 
-        for cmd, event in stream.escape.iteritems():
+        for cmd, event in stream.escape.items():
             c = self.counter()
             s.add_event_listener(event, c)
             s.consume(chr(ESC))
@@ -121,7 +121,7 @@ class TestScreen(unittest.TestCase):
         assert s.attributes == [[s._default(), s._default()]] * 2
         assert s.cursor_attributes == (("bold",), "default", "default")
 
-        s._print("f")
+        s._print(b"f")
         assert s.attributes == [
             [(("bold",), "default", "default"), s._default()],
             [s._default()                     , s._default()]
@@ -158,9 +158,9 @@ class TestScreen(unittest.TestCase):
         s = screen((2,2))
         assert s.attributes == [[s._default(), s._default()]] * 2
         s._select_graphic_rendition(1) # Bold
-        s._print("f")
-        s._print("o")
-        s._print("o")
+        s._print(b"f")
+        s._print(b"o")
+        s._print(b"o")
         assert s.attributes == [
             [(("bold",), "default", "default"), (("bold",), "default", "default")],
             [(("bold",), "default", "default"),                      s._default()],
@@ -168,7 +168,7 @@ class TestScreen(unittest.TestCase):
 
         s._home()
         s._select_graphic_rendition(0) # Reset
-        s._print("f")
+        s._print(b"f")
         assert s.attributes == [
             [s._default()                  , (("bold",), "default", "default")],
             [(("bold",), "default", "default"),                   s._default()],
@@ -185,13 +185,13 @@ class TestScreen(unittest.TestCase):
 
     def test_print(self):
         s = screen((3,3))
-        s._print("s")
+        s._print(b"s")
 
         assert s.display == ["s  ", "   ", "   "]
         assert s.cursor() == (1, 0)
 
         s.x = 1; s.y = 1
-        s._print("a")
+        s._print(b"a")
 
         assert s.display == ["s  ", " a ", "   "]
 

--- a/vt102/__init__.py
+++ b/vt102/__init__.py
@@ -58,9 +58,9 @@ import codecs
 
 from copy import copy
 
-from graphics import text, colors
-from control import *
-from escape import *
+from .graphics import text, colors
+from .control import *
+from .escape import *
 
 class stream:
     """
@@ -147,7 +147,7 @@ class stream:
             self.state = "charset-g0"
         elif char == ")":
             self.state = "charset-g1"
-        elif self.escape.has_key(num):
+        elif num in self.escape:
             self.dispatch(self.escape[num])
             self.state = "stream"
 
@@ -158,8 +158,9 @@ class stream:
         is dispatched here.
         """
 
-        if self.sequence.has_key(ord(char)):
-            self.dispatch(self.sequence[ord(char)], *self.params)
+        num = ord(char)
+        if num in self.sequence:
+            self.dispatch(self.sequence[num], *self.params)
         self.state = "stream"
         self.current_param = ""
         self.params = []
@@ -210,7 +211,7 @@ class stream:
         """
 
         num = ord(char)
-        if self.basic.has_key(num):
+        if num in self.basic:
             self.dispatch(self.basic[num])
         elif num == ESC:
             self.state = "escape"
@@ -264,7 +265,7 @@ class stream:
         :type function: callable
         """
 
-        if not self.listeners.has_key(event):
+        if event not in self.listeners:
             self.listeners[event] = []
 
         self.listeners[event].append(function)
@@ -292,7 +293,8 @@ class screen:
     The screen buffer can be accessed through the screen's `display` property.
     """
 
-    def __init__(self, (rows, cols), encoding="utf-8"):
+    def __init__(self, shape, encoding="utf-8"):
+        rows, cols = shape
         self.encoding = encoding
         self.decoder = codecs.getdecoder(encoding)
         self.size = (rows, cols)
@@ -362,7 +364,7 @@ class screen:
         """
         return (self.x, self.y)
 
-    def resize(self, (rows, cols)):
+    def resize(self, shape):
         """
         Resize the screen. If the requested screen size has more rows than the
         existing screen, rows will be added at the bottom. If the requested
@@ -373,6 +375,7 @@ class screen:
         size, columns will be added at the right, and it it has more, columns 
         will be clipped at the right.
         """
+        rows, cols = shape
 
         # Honestly though, you can't trust anyone these days...
         assert(rows > 0 and cols > 0)
@@ -762,11 +765,11 @@ class screen:
         Given some text attribute, set the current cursor attributes 
         appropriately.
         """
-        if text.has_key(attr):
+        if attr in text:
             self._text_attr(attr)
-        elif colors["foreground"].has_key(attr):
+        elif attr in colors["foreground"]:
             self._color_attr("foreground", attr)
-        elif colors["background"].has_key(attr):
+        elif attr in colors["background"]:
             self._color_attr("background", attr)
 
     def _default(self):

--- a/vt102/debug.py
+++ b/vt102/debug.py
@@ -2,4 +2,4 @@ from vt102 import stream
 
 class explainer(stream):
     def dispatch(self, event, *args):
-        print "%s %r" % (event, args)
+        print("%s %r" % (event, args))


### PR DESCRIPTION
I just found this module, it's rad! I made a few changes so that the tests pass in py3k as well as py2:
- `d.has_key(k)` --> `k in d`
- `iteritems()` --> `items()`
- explicit relative imports
- send bytes to `_print()` in tests

If there's anything I ought to test further, let me know!
